### PR TITLE
Use world axis for angular velocity and prediction (needs testing)

### DIFF
--- a/lua/vehicle/extensions/BeamMP/velocityVE.lua
+++ b/lua/vehicle/extensions/BeamMP/velocityVE.lua
@@ -139,8 +139,7 @@ local function addAngularVelocity(x, y, z, pitchAV, rollAV, yawAV)
 	end
 
 	local vel = vec3(x, y, z)
-	local toWorldAxisQuat = quat(obj:getRotation())
-	local av = vec3(pitchAV, rollAV, yawAV):rotated(toWorldAxisQuat)
+	local av = vec3(pitchAV, rollAV, yawAV)
 	--print("addAngularVelocity: pitchAV: "..pitchAV..", rollAV: "..rollAV..", yawAV: "..yawAV)
 	for nid, connected in pairs(isConnectedNode) do
 		local nodeWeight = obj:getNodeMass(nid)
@@ -157,12 +156,11 @@ local function setAngularVelocity(x, y, z, pitchAV, rollAV, yawAV)
 	local vel = vec3(x, y, z)
 	local vvel = vec3(obj:getVelocity())
 	local velDiff = vel - vvel
-
-	local pitchDiff = pitchAV - obj:getPitchAngularVelocity()
-	local rollDiff = rollAV - obj:getRollAngularVelocity()
-	local yawDiff = yawAV - obj:getYawAngularVelocity()
-
-	addAngularVelocity(velDiff.x, velDiff.y, velDiff.z, pitchDiff, rollDiff, yawDiff)
+	local rvel = vec3(pitchAV, rollAV, yawAV)
+	local vrvel = vec3(obj:getPitchAngularVelocity(), obj:getRollAngularVelocity(), obj:getYawAngularVelocity()):rotated(quat(obj:getRotation()))
+	local rvelDiff = rvel - vrvel
+	
+	addAngularVelocity(velDiff.x, velDiff.y, velDiff.z, rvelDiff.x, rvelDiff.y, rvelDiff.z)
 end
 
 v.mpVehicleType = "L"


### PR DESCRIPTION
- Sent angular velocity, prediction calculations, and addAngularVelocity() functions are now relative to the world axis instead of vehicle axis (should improve look in situations where the rotation of a vehicle is different between clients, for example fast rollover crashes)
- Fixed a bug where the rotation prediction is backwards if the vehicle is upside down
- Order of angular velocity vectors now correctly represents rotation around x, y, and z axis
- Slightly increased accuracy of angle correction (should only have minimal performance impact)

Seems to work fine when syncing two vehicles in singleplayer, but needs to be tested in multiplayer. 
Incompatible with older versions of the lua mod, because the sent angular velocity data has changed. 